### PR TITLE
Updating documentation for docker hub

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,51 @@
+# FDNS Microsoft Utilities Microservice
+
+Foundation Services (FDNS) Microsoft Utilities Microservice is the service used for parsing Microsoft formatted documents.
+
+## Getting Started
+
+To get started with the FDNS Microsoft Utilities Microservice you can use either `docker stack deploy` or `docker-compose`:
+
+```yaml
+version: '3.1'
+services:
+  fluentd:
+    image: fluent/fluentd
+    ports:
+      - "24224:24224"
+  fdns-ms-msft-utils:
+    image: cdcgov/fdns-ms-msft-utils
+    ports:
+      - "8087:8087"
+    depends_on:
+      - fluentd
+    environment:
+      MSFT_UTILS_PORT: 8087
+      MSFT_UTILS_FLUENTD_HOST: fluentd
+      MSFT_UTILS_FLUENTD_PORT: 24224
+```
+
+[![Try in PWD](https://raw.githubusercontent.com/play-with-docker/stacks/master/assets/images/button.png)](http://play-with-docker.com?stack=https://raw.githubusercontent.com/CDCgov/fdns-ms-msft-utils/master/stack.yml)
+
+## Source Code
+
+Please see [https://github.com/CDCgov/fdns-ms-msft-utils](https://github.com/CDCgov/fdns-ms-msft-utils) for the fdns-ms-msft-utils source repository.
+
+## Public Domain
+
+This repository constitutes a work of the United States Government and is not subject to domestic copyright protection under 17 USC § 105. This repository is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/). All contributions to this repository will be released under the CC0 dedication.
+
+## License
+
+The repository utilizes code licensed under the terms of the Apache Software License and therefore is licensed under ASL v2 or later.
+
+The container image in this repository is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Apache Software License for more details.
+
+## Privacy
+
+This repository contains only non-sensitive, publicly available data and information. All material and community participation is covered by the Surveillance Platform [Disclaimer](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md) and [Code of Conduct](https://github.com/CDCgov/template/blob/master/code-of-conduct.md).
+For more information about CDC's privacy policy, please visit [http://www.cdc.gov/privacy.html](http://www.cdc.gov/privacy.html).
+
+## Records
+
+This repository is not a source of government records, but is a copy to increase collaboration and collaborative potential. All government records will be published through the [CDC web site](http://www.cdc.gov).

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ docker-build:
 		-t fdns-ms-msft-utils \
 		--network=fdns-ms-msft-utils_default \
 		--rm \
-		--build-arg MSFT_UTILS_PORT=8086 \
+		--build-arg MSFT_UTILS_PORT=8087 \
 		--build-arg MSFT_UTILS_FLUENTD_HOST=fluentd \
 		--build-arg MSFT_UTILS_FLUENTD_PORT=24224 \
 		--build-arg MSFT_UTILS_PROXY_HOSTNAME= \
@@ -20,7 +20,7 @@ docker-run: docker-start
 docker-start:
 	docker-compose up -d
 	docker run -d \
-		-p 8086:8086 \
+		-p 8087:8087 \
 		--network=fdns-ms-msft-utils_default \
 		--name=fdns-ms-msft-utils_main \
 		fdns-ms-msft-utils

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 [![Build Status](https://travis-ci.org/CDCgov/fdns-ms-msft-utils.svg?branch=master)](https://travis-ci.org/CDCgov/fdns-ms-msft-utils)
 
 # FDNS Microsoft Utilities Microservice
+
 This is the repository with the Microsoft Utilities microservice for parsing Microsoft formatted documents.
 
 ## Running locally
+
 Carefully read the following instructions for information on how to build, run, and test this microservice in your local environment.
 
 ### Before you start
+
 You will need to have the following software installed to run this microservice in your local environment:
 
 - Docker, [Installation guides](https://docs.docker.com/install/)
@@ -17,7 +20,7 @@ You will need to have the following software installed to run this microservice 
 
 First, you'll need to build the image. You can build the image by running the following command:
 
-```
+```sh
 make docker-build
 ```
 
@@ -25,7 +28,7 @@ make docker-build
 
 Once the image has been built, you can run it with the following command:
 
-```
+```sh
 make docker-run
 ```
 
@@ -33,15 +36,16 @@ make docker-run
 
 To check if the microservice is running, open the following URL in your browser:
 
-[http://127.0.0.1:8086/](http://127.0.0.1:8086/)
+[http://127.0.0.1:8087/](http://127.0.0.1:8087/)
 
 ### Documentation
 
 To access the Swagger documentation, open the following URL in your browser:
 
-[http://127.0.0.1:8086/swagger-ui.html](http://127.0.0.1:8086/swagger-ui.html)
+[http://127.0.0.1:8087/swagger-ui.html](http://127.0.0.1:8087/swagger-ui.html)
 
 ### Docker Compose
+
 This microservice is designed to be used with other microservices. Please look at the [docker-compose](./docker-compose.yml) file for more information.
 
 ### OAuth 2 Configuration
@@ -52,22 +56,23 @@ __Scopes__: This application uses the following scope: `msft-utils.*`
 
 Please see the following environment variables for configuring with your OAuth 2 provider:
 
-* `OAUTH2_ACCESS_TOKEN_URI`: This is the introspection URL of your provider, ex: `https://hydra:4444/oauth2/introspect`
-* `OAUTH2_PROTECTED_URIS`: This is a path for which routes are to be restricted, ex: `/api/1.0/**`
-* `OAUTH2_CLIENT_ID`: This is your OAuth 2 client id with the provider
-* `OAUTH2_CLIENT_SECRET`: This is your OAuth 2 client secret with the provider
-* `SSL_VERIFYING_DISABLE`: This is an option to disable SSL verification, you can disable this when testing locally but this should be set to `false` for all production systems
+- `OAUTH2_ACCESS_TOKEN_URI`: This is the introspection URL of your provider, ex: `https://hydra:4444/oauth2/introspect`
+- `OAUTH2_PROTECTED_URIS`: This is a path for which routes are to be restricted, ex: `/api/1.0/**`
+- `OAUTH2_CLIENT_ID`: This is your OAuth 2 client id with the provider
+- `OAUTH2_CLIENT_SECRET`: This is your OAuth 2 client secret with the provider
+- `SSL_VERIFYING_DISABLE`: This is an option to disable SSL verification, you can disable this when testing locally but this should be set to `false` for all production systems
 
 ### Miscellaneous Configurations
 
 Here are other various configurations and their purposes:
 
-* `MSFT_UTILS_PORT`: This is a configurable port the application is set to run on
-* `MSFT_UTILS_FLUENTD_HOST`: This is the host of your [Fluentd](https://www.fluentd.org/)
-* `MSFT_UTILS_FLUENTD_PORT`: This is the port of your [Fluentd](https://www.fluentd.org/)
-* `MSFT_UTILS_PROXY_HOSTNAME`: This is the hostname of your environment for use with Swagger UI, ex: `api.my.org`
+- `MSFT_UTILS_PORT`: This is a configurable port the application is set to run on
+- `MSFT_UTILS_FLUENTD_HOST`: This is the host of your [Fluentd](https://www.fluentd.org/)
+- `MSFT_UTILS_FLUENTD_PORT`: This is the port of your [Fluentd](https://www.fluentd.org/)
+- `MSFT_UTILS_PROXY_HOSTNAME`: This is the hostname of your environment for use with Swagger UI, ex: `api.my.org`
   
 ## Public Domain
+
 This repository constitutes a work of the United States Government and is not
 subject to domestic copyright protection under 17 USC § 105. This repository is in
 the public domain within the United States, and copyright and related rights in
@@ -77,6 +82,7 @@ submitting a pull request you are agreeing to comply with this waiver of
 copyright interest.
 
 ## License
+
 The repository utilizes code licensed under the terms of the Apache Software
 License and therefore is licensed under ASL v2 or later.
 
@@ -93,8 +99,8 @@ program. If not, see https://www.apache.org/licenses/LICENSE-2.0.html
 
 The source code forked from other open source projects will inherit its license.
 
-
 ## Privacy
+
 This repository contains only non-sensitive, publicly available data and
 information. All material and community participation is covered by the
 Surveillance Platform [Disclaimer](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md)
@@ -102,6 +108,7 @@ and [Code of Conduct](https://github.com/CDCgov/template/blob/master/code-of-con
 For more information about CDC's privacy policy, please visit [http://www.cdc.gov/privacy.html](http://www.cdc.gov/privacy.html).
 
 ## Contributing
+
 Anyone is encouraged to contribute to the repository by [forking](https://help.github.com/articles/fork-a-repo)
 and submitting a pull request. (If you are new to GitHub, you might start with a
 [basic tutorial](https://help.github.com/articles/set-up-git).) By contributing
@@ -115,11 +122,13 @@ CDC including this GitHub page are subject to the [Presidential Records Act](htt
 and may be archived. Learn more at [https://www.cdc.gov/other/privacy.html](https://www.cdc.gov/other/privacy.html).
 
 ## Records
+
 This repository is not a source of government records, but is a copy to increase
 collaboration and collaborative potential. All government records will be
 published through the [CDC web site](https://www.cdc.gov).
 
 ## Notices
+
 Please refer to [CDC's Template Repository](https://github.com/CDCgov/template)
 for more information about [contributing to this repository](https://github.com/CDCgov/template/blob/master/CONTRIBUTING.md),
 [public domain notices and disclaimers](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.1'
 services:
   fluentd:
     image: fluent/fluentd

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -55,7 +55,7 @@ button:hover { background: #A7D5FF; outline: none; }
   --header 'Content-Type: multipart/form-data' \
   --header 'Accept: application/json' \
   -Ffile=@myfile.xlsx \
-  '<span class='origin'>http://127.0.0.1:8086/</span>api/1.0/xlsx/extract/json?sheetRange=A1%3AD1'
+  '<span class='origin'>http://127.0.0.1:8087/</span>api/1.0/xlsx/extract/json?sheetRange=A1%3AD1'
 </code></pre>
     </section>
   </div>

--- a/stack.yml
+++ b/stack.yml
@@ -1,0 +1,16 @@
+version: '3.1'
+services:
+  fluentd:
+    image: fluent/fluentd
+    ports:
+      - "24224:24224"
+  fdns-ms-msft-utils:
+    image: cdcgov/fdns-ms-msft-utils
+    ports:
+      - "8087:8087"
+    depends_on:
+      - fluentd
+    environment:
+      MSFT_UTILS_PORT: 8087
+      MSFT_UTILS_FLUENTD_HOST: fluentd
+      MSFT_UTILS_FLUENTD_PORT: 24224


### PR DESCRIPTION
This pull request updates the README with small fixes for markdown (lines after headers are suggested, etc.). 

This also adds a suggested documentation for Docker Hub and adds a `stack.yml` to be used with http://play-with-docker.com/

This also makes updates to the port to match what's defined in [fdns-ms-gateway](https://github.com/CDCgov/fdns-ms-gateway/blob/master/src/main/resources/application.properties#L39)