### PR TITLE
Updating the OAuth 2.0 Scope Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ transaction-logs
 docker-build-local.sh
 *.tar
 src/external
+.vscode

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This microservice is designed to be used with other microservices. Please look a
 
 This microservice is configurable so that it can be secured via an OAuth 2 provider.
 
-__Scopes__: This application uses the following scope: `msft-utils.*`
+__Scopes__: This application uses the following scope: `fdns.msft-utils`
 
 Please see the following environment variables for configuring with your OAuth 2 provider:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,7 @@ services:
     image: fluent/fluentd
     ports:
       - "24224:24224"
+  fdns-ms-stubbing:
+    image: cdcgov/fdns-ms-stubbing
+    ports:
+      - "3002:3002" 

--- a/src/main/java/gov/cdc/foundation/controller/DOCXController.java
+++ b/src/main/java/gov/cdc/foundation/controller/DOCXController.java
@@ -32,12 +32,20 @@ public class DOCXController {
 
 	private static final Logger logger = Logger.getLogger(DOCXController.class);
 
-	@RequestMapping(value = "extract", method = RequestMethod.POST, produces = MediaType.TEXT_PLAIN_VALUE)
-	@ApiOperation(value = "Extract text from DOCX", notes = "Extract text from DOCX")
+	@RequestMapping(
+		value = "extract",
+		method = RequestMethod.POST,
+		produces = MediaType.TEXT_PLAIN_VALUE
+	)
+	@ApiOperation(
+		value = "Extract text from DOCX",
+		notes = "Extract text from DOCX"
+	)
 	@ResponseBody
-	public ResponseEntity<?> extractDataToJson(@ApiParam(value = "DOCX File") @RequestParam("file") MultipartFile file,
-						  @ApiParam(value = "Expected file name") @RequestParam(value = "filename", required = false) String filename) {
-		
+	public ResponseEntity<?> extractDataToJson(
+		@ApiParam(value = "DOCX File") @RequestParam("file") MultipartFile file,
+		@ApiParam(value = "Expected file name") @RequestParam(value = "filename", required = false) String filename
+	) {		
 		Map<String, Object> log = new HashMap<String, Object>();
 		log.put(MessageHelper.CONST_METHOD, MessageHelper.METHOD_EXTRACTDATA_DOCX);
 		log.put(MessageHelper.CONST_FILENAME, file.getOriginalFilename());

--- a/src/main/java/gov/cdc/foundation/controller/MicrosoftController.java
+++ b/src/main/java/gov/cdc/foundation/controller/MicrosoftController.java
@@ -34,7 +34,6 @@ public class MicrosoftController {
 	@ResponseBody
 	public ResponseEntity<?> index() throws IOException {
 		ObjectMapper mapper = new ObjectMapper();
-		
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_INDEX);
 		
 		try {

--- a/src/main/java/gov/cdc/foundation/controller/XLSXController.java
+++ b/src/main/java/gov/cdc/foundation/controller/XLSXController.java
@@ -53,12 +53,20 @@ public class XLSXController {
 
 	private static final Logger logger = Logger.getLogger(XLSXController.class);
 
-	@RequestMapping(value = "sheets", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Get the list of sheets", notes = "Get the list of sheets of a XLSX file.")
+	@RequestMapping(
+		value = "sheets",
+		method = RequestMethod.POST,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Get the list of sheets",
+		notes = "Get the list of sheets of a XLSX file."
+	)
 	@ResponseBody
-	public ResponseEntity<?> getSheets(@ApiParam(value = "XLSX File") @RequestParam("file") MultipartFile file) throws IOException {
+	public ResponseEntity<?> getSheets(
+		@ApiParam(value = "XLSX File") @RequestParam("file") MultipartFile file
+	) throws IOException {
 		ObjectMapper mapper = new ObjectMapper();
-
 		Map<String, Object> log = new HashMap<String, Object>();
 		log.put(MessageHelper.CONST_METHOD, MessageHelper.METHOD_GETSHEETS);
 		log.put(MessageHelper.CONST_FILENAME, file.getOriginalFilename());
@@ -96,17 +104,23 @@ public class XLSXController {
 		}
 	}
 
-	@RequestMapping(value = "extract/json", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Extract data from XLSX to JSON", notes = "Extract data from XLSX to JSON")
+	@RequestMapping(
+		value = "extract/json",
+		method = RequestMethod.POST,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Extract data from XLSX to JSON",
+		notes = "Extract data from XLSX to JSON"
+	)
 	@ResponseBody
 	public ResponseEntity<?> extractDataToJson(@ApiParam(value = "XLSX File") @RequestParam("file") MultipartFile file,
-						  @ApiParam(value = "Sheet Name") @RequestParam(value = "sheetName", required = false) String sheetName,
-						  @ApiParam(value = "Sheet Range like A1:D1 or A2:A10") @RequestParam(value = "sheetRange") String sheetRange,
-						  @ApiParam(value = "Orientation", allowableValues = "portrait,landscape") @RequestParam(value = "orientation", required = false, defaultValue = "portrait") String orientation,
-						  @ApiParam(value = "Expected file name") @RequestParam(value = "filename", required = false) String filename) throws IOException {
-
+		@ApiParam(value = "Sheet Name") @RequestParam(value = "sheetName", required = false) String sheetName,
+		@ApiParam(value = "Sheet Range like A1:D1 or A2:A10") @RequestParam(value = "sheetRange") String sheetRange,
+		@ApiParam(value = "Orientation", allowableValues = "portrait,landscape") @RequestParam(value = "orientation", required = false, defaultValue = "portrait") String orientation,
+		@ApiParam(value = "Expected file name") @RequestParam(value = "filename", required = false) String filename
+	) throws IOException {
 		ObjectMapper mapper = new ObjectMapper();
-
 		Map<String, Object> log = new HashMap<String, Object>();
 		log.put(MessageHelper.CONST_METHOD, MessageHelper.METHOD_EXTRACTDATA_XLSX);
 		log.put(MessageHelper.CONST_FILENAME, file.getOriginalFilename());
@@ -153,15 +167,22 @@ public class XLSXController {
 	}
 
 
-	@RequestMapping(value = "extract/csv", method = RequestMethod.POST, produces = "text/csv")
-	@ApiOperation(value = "Extract data from XLSX to CSV", notes = "Extract data from XLSX to CSV")
+	@RequestMapping(
+		value = "extract/csv",
+		method = RequestMethod.POST,
+		produces = "text/csv"
+	)
+	@ApiOperation(
+		value = "Extract data from XLSX to CSV",
+		notes = "Extract data from XLSX to CSV"
+	)
 	@ResponseBody
 	public ResponseEntity<?> extractDataToCsv(@ApiParam(value = "XLSX File") @RequestParam("file") MultipartFile file,
-						 @ApiParam(value = "Sheet Name") @RequestParam(value = "sheetName", required = false) String sheetName,
-						 @ApiParam(value = "Sheet Range like A1:D1 or A2:A10") @RequestParam(value = "sheetRange") String sheetRange,
-						 @ApiParam(value = "Orientation", allowableValues = "portrait,landscape") @RequestParam(value = "orientation", required = false, defaultValue = "portrait") String orientation,
-						 @ApiParam(value = "Expected file name") @RequestParam(value = "filename", required = false) String filename) throws IOException {
-
+			@ApiParam(value = "Sheet Name") @RequestParam(value = "sheetName", required = false) String sheetName,
+			@ApiParam(value = "Sheet Range like A1:D1 or A2:A10") @RequestParam(value = "sheetRange") String sheetRange,
+			@ApiParam(value = "Orientation", allowableValues = "portrait,landscape") @RequestParam(value = "orientation", required = false, defaultValue = "portrait") String orientation,
+			@ApiParam(value = "Expected file name") @RequestParam(value = "filename", required = false) String filename
+	) throws IOException {
 		Map<String, Object> log = new HashMap<String, Object>();
 		log.put(MessageHelper.CONST_METHOD, MessageHelper.METHOD_EXTRACTDATA_XLSX);
 		log.put(MessageHelper.CONST_FILENAME, file.getOriginalFilename());
@@ -215,12 +236,20 @@ public class XLSXController {
 		}
 	}
 
-	@RequestMapping(value = "from/csv", method = RequestMethod.POST, produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-	@ApiOperation(value = "Transform a CSV to XLSX", notes = "Transform a CSV to XLSX")
+	@RequestMapping(
+		value = "from/csv",
+		method = RequestMethod.POST,
+		produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+	)
+	@ApiOperation(
+		value = "Transform a CSV to XLSX",
+		notes = "Transform a CSV to XLSX"
+	)
 	@ResponseBody
-	public ResponseEntity<?> convertCSVToXLSX(@ApiParam(value = "CSV File") @RequestParam("file") MultipartFile file,
-						 @ApiParam(value = "Expected file name") @RequestParam(value = "filename", required = false) String filename) throws IOException {
-
+	public ResponseEntity<?> convertCSVToXLSX(
+		@ApiParam(value = "CSV File") @RequestParam("file") MultipartFile file,
+		@ApiParam(value = "Expected file name") @RequestParam(value = "filename", required = false) String filename
+	) throws IOException {
 		Map<String, Object> log = new HashMap<String, Object>();
 		log.put(MessageHelper.CONST_METHOD, MessageHelper.METHOD_CONVERTCSVTOXLSX);
 		log.put(MessageHelper.CONST_FILENAME, file.getOriginalFilename());
@@ -272,7 +301,10 @@ public class XLSXController {
 		}
 	}
 
-	private JSONArray extractData(Sheet s, String range, String orientation) throws ServiceException {
+	private JSONArray extractData(
+		Sheet s, String range,
+		String orientation
+	) throws ServiceException {
 		// Check the range syntax
 		Regex regex = new Regex("[A-Z]+\\d+:[A-Z]+\\d+");
 		if (regex.matchEntire(range) == null)

--- a/src/main/java/gov/cdc/foundation/security/OAuth2Configuration.java
+++ b/src/main/java/gov/cdc/foundation/security/OAuth2Configuration.java
@@ -34,7 +34,7 @@ public class OAuth2Configuration extends ResourceServerConfigurerAdapter {
 			http
 				.authorizeRequests()
 				.antMatchers(HttpMethod.OPTIONS).permitAll()
-				.antMatchers(protectedURIs).access("#oauth2.hasScope('msft-utils')")
+				.antMatchers(protectedURIs).access("#oauth2.hasScope('fdns.msft-utils')")
 				.anyRequest().permitAll();
 		else
 			http

--- a/src/test/java/gov/cdc/foundation/MicrosoftApplicationTests.java
+++ b/src/test/java/gov/cdc/foundation/MicrosoftApplicationTests.java
@@ -32,7 +32,7 @@ import com.google.gson.JsonParser;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = {
 		"logging.fluentd.host=fluentd", 
 		"logging.fluentd.port=24224", 
-		"proxy.hostname=localhost", 
+		"proxy.hostname=", 
 		"security.oauth2.resource.user-info-uri=", 
 		"security.oauth2.protected=",
 		"security.oauth2.client.client-id=",

--- a/src/test/java/gov/cdc/foundation/OAuth2Test.java
+++ b/src/test/java/gov/cdc/foundation/OAuth2Test.java
@@ -1,6 +1,7 @@
 package gov.cdc.foundation;
 
 import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,16 +12,22 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
+import gov.cdc.helper.RequestHelper;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = {
-		"logging.fluentd.host=localhost", 
+		"logging.fluentd.host=fluentd", 
 		"logging.fluentd.port=24224", 
-		"proxy.hostname=localhost", 
-		"security.oauth2.resource.user-info-uri=", 
-		"security.oauth2.protected=/**",
-		"security.oauth2.client.client-id=",
-		"security.oauth2.client.client-secret=",
+		"proxy.hostname=", 
+		"security.oauth2.resource.user-info-uri=http://fdns-ms-stubbing:3002/oauth2/token/introspect",
+		"security.oauth2.protected=/api/1.0/**",
+		"security.oauth2.client.client-id=test",
+		"security.oauth2.client.client-secret=testsecret",
 		"ssl.verifying.disable=false" })
 @AutoConfigureMockMvc
 public class OAuth2Test {
@@ -28,11 +35,35 @@ public class OAuth2Test {
 	@Autowired
 	private TestRestTemplate restTemplate;
 	private String baseUrlPath = "/api/1.0/";
+	private String testToken = "Bearer testtoken";
 
 	@Test
-	public void indexPage() {
+	public void testUnauthenticated() {
 		ResponseEntity<String> response = restTemplate.getForEntity(baseUrlPath, String.class);
 		assertTrue(response.getStatusCodeValue() == 401);
 	}
 
+	@Test
+	public void testAthenticated() throws Exception {
+		setScope("fdns.msft-utils");
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Authorization", testToken);
+		HttpEntity<String> request = new HttpEntity<String>("{}", headers);
+
+		ResponseEntity<String> response = this.restTemplate.exchange(
+			baseUrlPath,
+			HttpMethod.GET,
+			request,
+			String.class
+		);
+
+		assertThat(response.getStatusCodeValue()).isEqualTo(200);
+	}
+
+	private void setScope(String scope) {
+		MultiValueMap<String, String> data = new LinkedMultiValueMap<>();
+		data.add("scope", scope);
+		RequestHelper.getInstance().executePost("http://fdns-ms-stubbing:3002/oauth2/mock", data);
+	}
 }


### PR DESCRIPTION
This pull request proposes a few changes:

- Changing the scopes to fall under a `fdns.*` namespace
- Adds support for CRUD operations (create, read, update and delete) and appends it at the end of the scope
- Adds support for wildcard scopes
- Adds the new https://github.com/CDCgov/fdns-ms-stubbing service for unit testing and tests OAuth 2.0 functionality